### PR TITLE
Added __array_ufunc__ to units.Value.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     python_requires=">=3.6, <4",
     install_requires=[
         "dataclasses;python_version<'3.7'",
-        "numpy",
+        "numpy>=1.13",
     ],
     project_urls={
         "Bug Reports": "https://github.com/ILAFF/ILAFF/issues",

--- a/src/ilaff/units/__init__.py
+++ b/src/ilaff/units/__init__.py
@@ -16,9 +16,7 @@ Examples:
     >>> import numpy
     >>> latt = Lattice()
     >>> numpy.array(range(0, 2)) * a(latt)
-    array([Value(value=0.0, unit=Unit(mass_dim=-1), scale=Lattice()),
-           Value(value=1.0, unit=Unit(mass_dim=-1), scale=Lattice())],
-          dtype=object)
+    Value(value=array([0., 1.]), unit=Unit(mass_dim=-1), scale=Lattice())
 
 
 To load values in lattice units directly into physical units based on a known
@@ -34,10 +32,7 @@ Examples:
     ...     n = tmpfile.write(b'0.49 0.48 0.50')
     ...     tmpfile.flush()
     ...     numpy.loadtxt(tmpfile.name) / a1
-    array([Value(value=0.9669021961200001, unit=Unit(mass_dim=1), scale=Physical()),
-           Value(value=0.9471694982400001, unit=Unit(mass_dim=1), scale=Physical()),
-           Value(value=0.986634894, unit=Unit(mass_dim=1), scale=Physical())],
-          dtype=object)
+    Value(value=array([0.9669022 , 0.9471695 , 0.98663489]), unit=Unit(mass_dim=1), scale=Physical())
 
 
 It is also possible to use the Value constructor directly to initialise

--- a/src/ilaff/units/value.py
+++ b/src/ilaff/units/value.py
@@ -280,3 +280,8 @@ class Value:
 
     def sqrt(self) -> "Value":
         return self.root(2)
+
+    __array_ufunc__ = None
+    """Ensures proper numpy integration by preventing numpy from
+    distributing across the numpy array before the value is unwrapped by
+    rmul. Only works for numpy >= 1.13"""


### PR DESCRIPTION
This ensures proper numpy integration for numpy >= 1.13.