### PR TITLE
Renamed Unit and Value to Dimension and Quantity

### DIFF
--- a/src/ilaff/units/__init__.py
+++ b/src/ilaff/units/__init__.py
@@ -1,12 +1,12 @@
 """Dimensional analysis for use in lattice QCD analyses.
 
-A seperate instance of Lattice should be constructed for each independent
+A separate instance of ``Lattice`` should be constructed for each independent
 lattice spacing. This ensures that the independent lattice spacings are kept
 distinct.
 
-New values should generally be constructed by multiplying a float, numpy array,
-or other raw value by one of the provided unit values (e.g. units.MeV,
-units.GeV, units.fm, or units.a(scale)).
+New quantities should generally be constructed by multiplying a float, numpy
+array, or other raw value by one of the provided units (i.e. ``units.MeV``, 
+``units.GeV``, ``units.fm``, or ``units.a(scale)``).
 
 Examples:
     >>> str(135.0 * MeV)
@@ -18,7 +18,7 @@ Examples:
     >>> str(0.068 / a(latt))
     '0.068 a^-1'
     >>> numpy.array(range(0, 2)) * a(latt)
-    Value(value=array([0., 1.]), unit=Unit(mass_dim=-1), scale=Lattice())
+    Quantity(value=array([0., 1.]), dimension=Dimension(mass_dim=-1), scale=Lattice())
 
 
 To load values in lattice units directly into physical units based on a known
@@ -34,17 +34,17 @@ Examples:
     ...     n = tmpfile.write(b'0.49 0.48 0.50')
     ...     tmpfile.flush()
     ...     numpy.loadtxt(tmpfile.name) / a1
-    Value(value=array([0.9669022 , 0.9471695 , 0.98663489]), unit=Unit(mass_dim=1), scale=Physical())
+    Quantity(value=array([0.9669022 , 0.9471695 , 0.98663489]), dimension=Dimension(mass_dim=1), scale=Physical())
 
 
-It is also possible to use the Value constructor directly to initialise
-values from their mass dimension, but this is not recommended for physical
-units as it relies on the internal representation of the units. However, it
-works as expected for lattice units.
+It is also possible to use the ``Quantity`` constructor directly to initialise
+quantities from their mass dimension, but this is not recommended for physical
+units as it relies on the internal representation of the units in ``Quantity``.
+However, it works as expected for lattice units.
 
 Example:
     >>> latt = Lattice()
-    >>> str(Value(
+    >>> str(Quantity(
     ...     16.0,
     ...     Length,
     ...     latt,
@@ -52,7 +52,7 @@ Example:
     '16.0 a'
 
 
-Values can be negated, raised to integer powers or rooted.
+Quantities can be negated, raised to integer powers or rooted.
 
 Examples:
     >>> m2 = 0.0182 * GeV**2
@@ -68,8 +68,8 @@ Examples:
     '0.13490737563232044 GeV'
 
 
-Values with compatible scales can be added, subtracted, multiplied, divided,
-and compared.
+Quantities with compatible scales and dimensions can be added, subtracted,
+multiplied, divided, and compared.
 
 Examples:
     >>> m = 0.135 * GeV
@@ -95,10 +95,10 @@ Examples:
     True
 
 
-In order to perform these operations, values must be converted to the same
-scale using v.set_scale(pre_value, post_value), where pre_value is some value
-in v's current scale, and post_value is the corresponding value in the target
-scale.
+In order to perform these operations, quantities must be converted to the same
+scale using ``q.set_scale(current, target)``, where ``current`` is some
+quantity in ``q``'s current scale, and ``target`` is the corresponding quantity
+in the target scale.
 
 Examples:
     >>> latt = Lattice()
@@ -112,7 +112,7 @@ Examples:
     '0.33232697880000006 GeV'
 
 
-Values can be extracted in specific units using the in_unit method.
+Values can be extracted in specific units using the ``in_unit`` method.
 
 Example:
     >>> m = 135.0 * MeV
@@ -125,11 +125,11 @@ Example:
 """
 
 from .scale import Physical, Lattice, MeV, GeV, fm, a, one
-from .unit import Unit, Mass, Length, Scalar
-from .value import Value, Scale
+from .dimension import Dimension, Mass, Length, Scalar
+from .quantity import Quantity, Scale
 
 __all__ = [
     'Physical', 'Lattice', 'MeV', 'GeV', 'fm', 'a', 'one',
-    'Unit', 'Mass', 'Length', 'Scalar',
-    'Value', 'Scale',
+    'Dimension', 'Mass', 'Length', 'Scalar',
+    'Quantity', 'Scale',
 ]

--- a/src/ilaff/units/dimension.py
+++ b/src/ilaff/units/dimension.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
-class Unit:
+class Dimension:
     mass_dim: int
 
     def __str__(self) -> str:
@@ -16,31 +16,31 @@ class Unit:
             return "length^{}".format(-self.mass_dim)
         return "scalar"
 
-    def __mul__(self, other: "Unit") -> "Unit":
-        return Unit(self.mass_dim + other.mass_dim)
+    def __mul__(self, other: "Dimension") -> "Dimension":
+        return Dimension(self.mass_dim + other.mass_dim)
 
-    def __truediv__(self, other: "Unit") -> "Unit":
-        return Unit(self.mass_dim - other.mass_dim)
+    def __truediv__(self, other: "Dimension") -> "Dimension":
+        return Dimension(self.mass_dim - other.mass_dim)
 
-    def __pow__(self, exponent: int) -> "Unit":
-        return Unit(self.mass_dim * exponent)
+    def __pow__(self, exponent: int) -> "Dimension":
+        return Dimension(self.mass_dim * exponent)
 
-    def root(self, exponent: int) -> "Unit":
+    def root(self, exponent: int) -> "Dimension":
         if self.mass_dim % exponent != 0:
             if exponent == 2:
                 raise ValueError("Can't take square root of {}".format(self))
             if exponent == 3:
                 raise ValueError("Can't take cube root of {}".format(self))
             raise ValueError("Can't take {}-th root of {}".format(exponent, self))
-        return Unit(self.mass_dim // exponent)
+        return Dimension(self.mass_dim // exponent)
 
-    def sqrt(self) -> "Unit":
+    def sqrt(self) -> "Dimension":
         return self.root(2)
 
     def scale(self, scale: float) -> float:
         return scale**self.mass_dim
 
 
-Scalar = Unit(0)
-Mass = Unit(1)
-Length = Unit(-1)
+Scalar = Dimension(0)
+Mass = Dimension(1)
+Length = Dimension(-1)

--- a/src/ilaff/units/quantity.py
+++ b/src/ilaff/units/quantity.py
@@ -2,56 +2,56 @@ import abc
 from dataclasses import dataclass
 from typing import Any, Tuple
 
-from .unit import Unit, Scalar
+from .dimension import Dimension, Scalar
 
 
 class Scale(abc.ABC):
     @abc.abstractmethod
-    def unit(self, unit: Unit) -> Tuple["Value", str]: ...
+    def unit(self, dimension: Dimension) -> Tuple["Quantity", str]: ...
 
 
 @dataclass(frozen=True, eq=False, order=False)
-class Value:
+class Quantity:
     value: Any
-    unit: Unit
+    dimension: Dimension
     scale: Scale
 
-    def set_scale(self, curr: "Value", new: "Value") -> "Value":
+    def set_scale(self, curr: "Quantity", new: "Quantity") -> "Quantity":
         if self.scale != curr.scale:
             raise ValueError("Error setting scale: Can't set scale for {} with {}".format(self, curr))
-        if curr.unit != new.unit:
+        if curr.dimension != new.dimension:
             raise ValueError("Error setting scale: {} and {} have different mass dimensions".format(curr, new))
         if curr.scale == new.scale:
             raise ValueError("Error setting scale: Initial and final scale are the same")
-        return Value(
-            self.value * self.unit.scale(
-                (new.value / curr.value)**(1 / curr.unit.mass_dim)
+        return Quantity(
+            self.value * self.dimension.scale(
+                (new.value / curr.value)**(1 / curr.dimension.mass_dim)
             ),
-            self.unit,
+            self.dimension,
             new.scale,
         )
 
-    def in_unit(self, val: "Value") -> Any:
+    def in_unit(self, val: "Quantity") -> Any:
         try:
             res = self / val
         except ValueError:
             raise ValueError("Can't convert units: incompatible scales")
-        if res.unit.mass_dim != 0:
+        if res.dimension.mass_dim != 0:
             raise ValueError(
                 "Can't convert units: incompatible mass dimensions {} and {}"
-                .format(self.unit.mass_dim, val.unit.mass_dim)
+                .format(self.dimension.mass_dim, val.dimension.mass_dim)
             )
         return res.value
 
     def __str__(self) -> str:
-        unit, suffix = self.scale.unit(self.unit)
+        unit, suffix = self.scale.unit(self.dimension)
         if suffix != "":
             return str(self.in_unit(unit)) + " " + suffix
         else:
             return str(self.in_unit(unit))
 
     def __format__(self, format_str: str) -> str:
-        unit, suffix = self.scale.unit(self.unit)
+        unit, suffix = self.scale.unit(self.dimension)
         if suffix != "":
             return ("{:" + format_str + "} {}").format(
                 self.in_unit(unit),
@@ -63,249 +63,249 @@ class Value:
             )
 
     def __eq__(self, other: Any) -> Any:
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't compare values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't compare values: incompatible scales")
 
             return self.value == other.value
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't compare scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't compare scalar to mass dimension {}".format(self.dimension.mass_dim))
 
             return self.value == other
 
     def __lt__(self, other: Any) -> Any:
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't compare values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't compare values: incompatible scales")
 
             return self.value < other.value
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't compare scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't compare scalar to mass dimension {}".format(self.dimension.mass_dim))
 
             return self.value < other
 
     def __le__(self, other: Any) -> Any:
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't compare values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't compare values: incompatible scales")
 
             return self.value <= other.value
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't compare scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't compare scalar to mass dimension {}".format(self.dimension.mass_dim))
 
             return self.value <= other
 
     def __gt__(self, other: Any) -> Any:
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't compare values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't compare values: incompatible scales")
 
             return self.value > other.value
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't compare scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't compare scalar to mass dimension {}".format(self.dimension.mass_dim))
 
             return self.value > other
 
     def __ge__(self, other: Any) -> Any:
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't compare values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't compare values: incompatible scales")
 
             return self.value >= other.value
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't compare scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't compare scalar to mass dimension {}".format(self.dimension.mass_dim))
 
             return self.value >= other
 
-    def __neg__(self) -> "Value":
-        return Value(
+    def __neg__(self) -> "Quantity":
+        return Quantity(
             -self.value,
-            self.unit,
+            self.dimension,
             self.scale,
         )
 
-    def __add__(self, other: Any) -> "Value":
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+    def __add__(self, other: Any) -> "Quantity":
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't add values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't add values: incompatible scales")
 
-            return Value(
+            return Quantity(
                 self.value + other.value,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't add scalar to mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't add scalar to mass dimension {}".format(self.dimension.mass_dim))
 
-            return Value(
+            return Quantity(
                 self.value + other,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
 
-    def __radd__(self, other: Any) -> "Value":
-        if self.unit != Scalar:
-            raise ValueError("Can't add mass dimension {} to scalar".format(self.unit.mass_dim))
+    def __radd__(self, other: Any) -> "Quantity":
+        if self.dimension != Scalar:
+            raise ValueError("Can't add mass dimension {} to scalar".format(self.dimension.mass_dim))
 
-        return Value(
+        return Quantity(
             other + self.value,
-            self.unit,
+            self.dimension,
             self.scale,
         )
 
-    def __sub__(self, other: Any) -> "Value":
-        if isinstance(other, Value):
-            if self.unit != other.unit:
+    def __sub__(self, other: Any) -> "Quantity":
+        if isinstance(other, Quantity):
+            if self.dimension != other.dimension:
                 raise ValueError(
                     "Can't subtract values: incompatible mass dimensions {} and {}"
-                    .format(self.unit.mass_dim, other.unit.mass_dim)
+                    .format(self.dimension.mass_dim, other.dimension.mass_dim)
                 )
 
-            if self.unit != Scalar and self.scale != other.scale:
+            if self.dimension != Scalar and self.scale != other.scale:
                 raise ValueError("Can't subtract values: incompatible scales")
 
-            return Value(
+            return Quantity(
                 self.value - other.value,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
         else:
-            if self.unit != Scalar:
-                raise ValueError("Can't subtract scalar from mass dimension {}".format(self.unit.mass_dim))
+            if self.dimension != Scalar:
+                raise ValueError("Can't subtract scalar from mass dimension {}".format(self.dimension.mass_dim))
 
-            return Value(
+            return Quantity(
                 self.value - other,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
 
-    def __rsub__(self, other: Any) -> "Value":
-        if self.unit != Scalar:
-            raise ValueError("Can't subtract mass dimension {} from scalar".format(self.unit.mass_dim))
+    def __rsub__(self, other: Any) -> "Quantity":
+        if self.dimension != Scalar:
+            raise ValueError("Can't subtract mass dimension {} from scalar".format(self.dimension.mass_dim))
 
-        return Value(
+        return Quantity(
             other - self.value,
-            self.unit,
+            self.dimension,
             self.scale,
         )
 
-    def __mul__(self, other: Any) -> "Value":
-        if isinstance(other, Value):
-            if other.unit == Scalar:
+    def __mul__(self, other: Any) -> "Quantity":
+        if isinstance(other, Quantity):
+            if other.dimension == Scalar:
                 scale = self.scale
-            elif self.unit == Scalar:
+            elif self.dimension == Scalar:
                 scale = other.scale
             elif self.scale == other.scale:
                 scale = self.scale
             else:
                 raise ValueError("Can't multiply values: incompatible scales")
 
-            return Value(
+            return Quantity(
                 self.value * other.value,
-                self.unit * other.unit,
+                self.dimension * other.dimension,
                 scale,
             )
         else:
-            return Value(
+            return Quantity(
                 self.value * other,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
 
-    def __rmul__(self, other: Any) -> "Value":
-        return Value(
+    def __rmul__(self, other: Any) -> "Quantity":
+        return Quantity(
             other * self.value,
-            self.unit,
+            self.dimension,
             self.scale,
         )
 
-    def __truediv__(self, other: Any) -> "Value":
-        if isinstance(other, Value):
-            if other.unit == Scalar:
+    def __truediv__(self, other: Any) -> "Quantity":
+        if isinstance(other, Quantity):
+            if other.dimension == Scalar:
                 scale = self.scale
-            elif self.unit == Scalar:
+            elif self.dimension == Scalar:
                 scale = other.scale
             elif self.scale == other.scale:
                 scale = self.scale
             else:
                 raise ValueError("Can't divide values: incompatible scales")
 
-            return Value(
+            return Quantity(
                 self.value / other.value,
-                self.unit / other.unit,
+                self.dimension / other.dimension,
                 scale,
             )
         else:
-            return Value(
+            return Quantity(
                 self.value / other,
-                self.unit,
+                self.dimension,
                 self.scale,
             )
 
-    def __rtruediv__(self, other: Any) -> "Value":
-        return Value(
+    def __rtruediv__(self, other: Any) -> "Quantity":
+        return Quantity(
             other / self.value,
-            Scalar / self.unit,
+            Scalar / self.dimension,
             self.scale,
         )
 
-    def __pow__(self, other: int) -> "Value":
-        return Value(
+    def __pow__(self, other: int) -> "Quantity":
+        return Quantity(
             self.value**other,
-            self.unit**other,
+            self.dimension**other,
             self.scale,
         )
 
-    def root(self, other: int) -> "Value":
-        return Value(
+    def root(self, other: int) -> "Quantity":
+        return Quantity(
             self.value**(1 / other),
-            self.unit.root(other),
+            self.dimension.root(other),
             self.scale,
         )
 
-    def sqrt(self) -> "Value":
+    def sqrt(self) -> "Quantity":
         return self.root(2)
 
     __array_ufunc__ = None

--- a/src/ilaff/units/scale.py
+++ b/src/ilaff/units/scale.py
@@ -1,39 +1,39 @@
 from dataclasses import dataclass
 from typing import Tuple
 
-from .unit import Unit, Mass, Length, Scalar
-from .value import Scale, Value
+from .dimension import Dimension, Mass, Length, Scalar
+from .quantity import Scale, Quantity
 
 
 @dataclass(frozen=True)
 class Physical(Scale):
-    def unit(self, unit: Unit) -> Tuple[Value, str]:
-        if unit.mass_dim == 1:
+    def unit(self, dimension: Dimension) -> Tuple[Quantity, str]:
+        if dimension.mass_dim == 1:
             return (GeV, "GeV")
-        if unit.mass_dim == -1:
+        if dimension.mass_dim == -1:
             return (fm, "fm")
-        if unit.mass_dim > 0:
-            return (GeV**unit.mass_dim, "GeV^{}".format(unit.mass_dim))
-        if unit.mass_dim < 0:
-            return (fm**(-unit.mass_dim), "fm^{}".format(-unit.mass_dim))
+        if dimension.mass_dim > 0:
+            return (GeV**dimension.mass_dim, "GeV^{}".format(dimension.mass_dim))
+        if dimension.mass_dim < 0:
+            return (fm**(-dimension.mass_dim), "fm^{}".format(-dimension.mass_dim))
         return (one, "")
 
 
 @dataclass(frozen=True, eq=False)
 class Lattice(Scale):
-    def unit(self, unit: Unit) -> Tuple[Value, str]:
-        if unit.mass_dim == -1:
+    def unit(self, dimension: Dimension) -> Tuple[Quantity, str]:
+        if dimension.mass_dim == -1:
             return (a(self), "a")
-        if unit.mass_dim != 0:
-            return (a(self)**(-unit.mass_dim), "a^{}".format(-unit.mass_dim))
+        if dimension.mass_dim != 0:
+            return (a(self)**(-dimension.mass_dim), "a^{}".format(-dimension.mass_dim))
         return (one, "")
 
 
-MeV = Value(0.001, Mass, Physical())
-GeV = Value(1.0, Mass, Physical())
-fm = Value(1.0 / 0.1973269788, Length, Physical())
-one = Value(1.0, Scalar, Physical())
+MeV = Quantity(0.001, Mass, Physical())
+GeV = Quantity(1.0, Mass, Physical())
+fm = Quantity(1.0 / 0.1973269788, Length, Physical())
+one = Quantity(1.0, Scalar, Physical())
 
 
-def a(scale: Scale) -> Value:
-    return Value(1.0, Length, scale)
+def a(scale: Scale) -> Quantity:
+    return Quantity(1.0, Length, scale)

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -6,8 +6,8 @@ def test_mismatched() -> None:
     latt = units.Lattice()
     latt2 = units.Lattice()
 
-    a = units.Value(1.0, units.Length, latt)
-    a2 = units.Value(1.0, units.Length, latt2)
+    a = units.Quantity(1.0, units.Length, latt)
+    a2 = units.Quantity(1.0, units.Length, latt2)
 
     with pytest.raises(ValueError):
         a + a2
@@ -23,8 +23,8 @@ def test_convert() -> None:
     latt = units.Lattice()
     latt2 = units.Lattice()
 
-    a = units.Value(1.0, units.Length, latt)
-    a2 = units.Value(1.0, units.Length, latt2)
+    a = units.Quantity(1.0, units.Length, latt)
+    a2 = units.Quantity(1.0, units.Length, latt2)
 
     a_phys = a.set_scale(a, 0.0904 * units.fm)
     with pytest.raises(ValueError):
@@ -59,7 +59,7 @@ def test_format() -> None:
     assert str(units.Scalar) == "scalar"
 
     with pytest.raises(TypeError):
-        units.Value(
+        units.Quantity(
             0.0,
             units.Length,
             units.Scale()  # type: ignore
@@ -89,7 +89,7 @@ def test_format() -> None:
 
 
 def test_roots() -> None:
-    assert units.unit.Unit(-4).sqrt() == units.unit.Unit(-2)
+    assert units.Dimension(-4).sqrt() == units.Dimension(-2)
 
     latt = units.Lattice()
     t_current = (21 - 16) * units.a(latt)


### PR DESCRIPTION
Makes documentation more clear
Clarifies distinction between quantity (has units) and its value (doesn't)
Clarifies distinction between a mass Dimension and e.g. units.fm

For more details, see #9 